### PR TITLE
Update SDL TTF to master (7dbd7cd826d6)

### DIFF
--- a/package/sdl_ttf/sdl_ttf.hash
+++ b/package/sdl_ttf/sdl_ttf.hash
@@ -1,2 +1,2 @@
 # Locally calculated
-sha256	724cd895ecf4da319a3ef164892b72078bd92632a5d812111261cde248ebcdb7	SDL_ttf-2.0.11.tar.gz
+sha256	d22b229d16b72bdb29d252aef059a0e96aac6c4148792e21cb0cf40adb6c7cb7	7dbd7cd826d6.tar.gz

--- a/package/sdl_ttf/sdl_ttf.mk
+++ b/package/sdl_ttf/sdl_ttf.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-SDL_TTF_VERSION = 2.0.11
-SDL_TTF_SOURCE = SDL_ttf-$(SDL_TTF_VERSION).tar.gz
-SDL_TTF_SITE = http://www.libsdl.org/projects/SDL_ttf/release
+SDL_TTF_VERSION = 7dbd7cd826d6
+SDL_TTF_SOURCE = $(SDL_TTF_VERSION).tar.gz
+SDL_TTF_SITE = https://hg.libsdl.org/SDL_ttf/archive
 SDL_TTF_LICENSE = Zlib
 SDL_TTF_LICENSE_FILES = COPYING
 


### PR DESCRIPTION
SDL TTF master adds support for non-square font scaling:
https://hg.libsdl.org/SDL_ttf/rev/7dbd7cd826d6